### PR TITLE
Refactor : 매장 등록 시 이미지 저장과 운영 시간 저장 배치 처리

### DIFF
--- a/src/main/java/org/kwakmunsu/dingdongpang/domain/inquiry/service/dto/response/InquiryByMerchantResponse.java
+++ b/src/main/java/org/kwakmunsu/dingdongpang/domain/inquiry/service/dto/response/InquiryByMerchantResponse.java
@@ -1,10 +1,7 @@
 package org.kwakmunsu.dingdongpang.domain.inquiry.service.dto.response;
 
-import static org.kwakmunsu.dingdongpang.global.util.TimeConverter.dateTimeToString;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.sql.Timestamp;
-import java.time.LocalDateTime;
 import lombok.Builder;
 import org.kwakmunsu.dingdongpang.domain.inquiry.entity.Inquiry;
 

--- a/src/main/java/org/kwakmunsu/dingdongpang/domain/inquiry/service/dto/response/InquiryResponse.java
+++ b/src/main/java/org/kwakmunsu/dingdongpang/domain/inquiry/service/dto/response/InquiryResponse.java
@@ -1,10 +1,7 @@
 package org.kwakmunsu.dingdongpang.domain.inquiry.service.dto.response;
 
-import static org.kwakmunsu.dingdongpang.global.util.TimeConverter.dateTimeToString;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.sql.Timestamp;
-import java.time.LocalDateTime;
 import lombok.Builder;
 import org.kwakmunsu.dingdongpang.domain.inquiry.entity.Inquiry;
 

--- a/src/main/java/org/kwakmunsu/dingdongpang/domain/notification/service/dto/NotifyDetailResponse.java
+++ b/src/main/java/org/kwakmunsu/dingdongpang/domain/notification/service/dto/NotifyDetailResponse.java
@@ -1,10 +1,7 @@
 package org.kwakmunsu.dingdongpang.domain.notification.service.dto;
 
-import static org.kwakmunsu.dingdongpang.global.util.TimeConverter.dateTimeToString;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.sql.Timestamp;
-import java.time.LocalDateTime;
 import java.util.List;
 import lombok.Builder;
 import org.kwakmunsu.dingdongpang.domain.notification.entity.Notification;

--- a/src/main/java/org/kwakmunsu/dingdongpang/domain/notification/service/dto/NotifyPreviewResponse.java
+++ b/src/main/java/org/kwakmunsu/dingdongpang/domain/notification/service/dto/NotifyPreviewResponse.java
@@ -1,10 +1,7 @@
 package org.kwakmunsu.dingdongpang.domain.notification.service.dto;
 
-import static org.kwakmunsu.dingdongpang.global.util.TimeConverter.dateTimeToString;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.sql.Timestamp;
-import java.time.LocalDateTime;
 import lombok.Builder;
 import org.kwakmunsu.dingdongpang.domain.notification.entity.Notification;
 

--- a/src/main/java/org/kwakmunsu/dingdongpang/domain/shop/repository/shopoperation/ShopOperationTimeBulkRepository.java
+++ b/src/main/java/org/kwakmunsu/dingdongpang/domain/shop/repository/shopoperation/ShopOperationTimeBulkRepository.java
@@ -1,0 +1,38 @@
+package org.kwakmunsu.dingdongpang.domain.shop.repository.shopoperation;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.kwakmunsu.dingdongpang.domain.shop.entity.ShopOperationTime;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class ShopOperationTimeBulkRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public void saveOperationTimesBulk(List<ShopOperationTime> operationTimes, Long shopId) {
+        if (operationTimes.isEmpty()) return;
+
+        String sql = """
+            INSERT INTO shop_operation_time (shop_id, day_of_week, open_time, close_time, is_closed, created_at, updated_at) 
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """;
+
+        LocalDateTime now = LocalDateTime.now();
+
+        jdbcTemplate.batchUpdate(sql, operationTimes, operationTimes.size(),
+                (ps, ot) -> {
+                    ps.setLong(1, shopId);
+                    ps.setString(2, ot.getDayOfWeek().toString());
+                    ps.setObject(3, ot.getOpenTime());
+                    ps.setObject(4, ot.getCloseTime());
+                    ps.setBoolean(5, ot.isClosed());
+                    ps.setObject(6, now);
+                    ps.setObject(7, now);
+                });
+    }
+
+}

--- a/src/main/java/org/kwakmunsu/dingdongpang/domain/shop/repository/shopoperation/ShopOperationTimeRepository.java
+++ b/src/main/java/org/kwakmunsu/dingdongpang/domain/shop/repository/shopoperation/ShopOperationTimeRepository.java
@@ -2,6 +2,7 @@ package org.kwakmunsu.dingdongpang.domain.shop.repository.shopoperation;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.kwakmunsu.dingdongpang.domain.shop.entity.Shop;
 import org.kwakmunsu.dingdongpang.domain.shop.entity.ShopOperationTime;
 import org.kwakmunsu.dingdongpang.domain.shop.repository.shopoperation.dto.ShopOperationTimeResponse;
 import org.springframework.stereotype.Repository;
@@ -11,9 +12,14 @@ import org.springframework.stereotype.Repository;
 public class ShopOperationTimeRepository {
 
     private final ShopOperationTimeJpaRepository shopOperationTimeJpaRepository;
+    private final ShopOperationTimeBulkRepository shopOperationTimeBulkRepository;
 
     public void saveAll(List<ShopOperationTime> operationTimes) {
         shopOperationTimeJpaRepository.saveAll(operationTimes);
+    }
+
+    public void saveAll(List<ShopOperationTime> operationTimes, Shop shop) {
+        shopOperationTimeBulkRepository.saveOperationTimesBulk(operationTimes, shop.getId());
     }
 
     public List<ShopOperationTimeResponse> findByShopId(Long shopId) {

--- a/src/main/java/org/kwakmunsu/dingdongpang/domain/shop/service/ShopCommandService.java
+++ b/src/main/java/org/kwakmunsu/dingdongpang/domain/shop/service/ShopCommandService.java
@@ -11,7 +11,6 @@ import org.kwakmunsu.dingdongpang.domain.shop.repository.shopoperation.ShopOpera
 import org.kwakmunsu.dingdongpang.domain.shop.service.dto.request.OperationTimeServiceRequest;
 import org.kwakmunsu.dingdongpang.domain.shop.service.dto.request.ShopRegisterServiceRequest;
 import org.kwakmunsu.dingdongpang.domain.shop.service.dto.request.ShopUpdateServiceRequest;
-import org.kwakmunsu.dingdongpang.domain.shopimage.entity.ShopImage;
 import org.kwakmunsu.dingdongpang.domain.shopimage.repository.ShopImageRepository;
 import org.kwakmunsu.dingdongpang.infrastructure.s3.S3Provider;
 import org.locationtech.jts.geom.Point;
@@ -37,7 +36,7 @@ public class ShopCommandService {
 
         if (!request.imageFiles().isEmpty()) {
             List<String> uploadedImages = s3Provider.uploadImages(request.imageFiles());
-            saveShopImages(uploadedImages, shop);
+            shopImageRepository.saveAll(uploadedImages, shop);
         }
 
         List<OperationTimeServiceRequest> operationTimeRequests = request.operationTimeRequests();
@@ -56,7 +55,7 @@ public class ShopCommandService {
 
         if (!request.imageFiles().isEmpty()) {
             List<String> uploadedImages = s3Provider.uploadImages(request.imageFiles());
-            saveShopImages(uploadedImages, shop);
+            shopImageRepository.saveAll(uploadedImages, shop);
         }
 
         List<OperationTimeServiceRequest> operationTimeRequests = request.operationTimeRequests();
@@ -64,13 +63,6 @@ public class ShopCommandService {
         shopOperationTimeRepository.findByShopId(shop.getId());
         saveShopOperationTimes(operationTimeRequests, shop);
 
-    }
-
-    private void saveShopImages(List<String> uploadedImages, Shop shop) {
-        List<ShopImage> images = uploadedImages.stream()
-                .map(image -> ShopImage.create(shop.getId(), image))
-                .toList();
-        shopImageRepository.saveAll(images);
     }
 
     private void saveShopOperationTimes(List<OperationTimeServiceRequest> operationTimeRequests, Shop shop) {

--- a/src/main/java/org/kwakmunsu/dingdongpang/domain/shop/service/dto/request/OperationTimeServiceRequest.java
+++ b/src/main/java/org/kwakmunsu/dingdongpang/domain/shop/service/dto/request/OperationTimeServiceRequest.java
@@ -5,8 +5,8 @@ import lombok.Builder;
 
 @Builder
 public record OperationTimeServiceRequest(
-        DayOfWeek dayOfWeek, // java.time.DayOfWeek
-        String openTime,     // "HH:mm" 포맷 (필요시 LocalTime으로 후처리)
+        DayOfWeek dayOfWeek,
+        String openTime,
         String closeTime,
         boolean isClosed
 ) {

--- a/src/main/java/org/kwakmunsu/dingdongpang/domain/shopimage/repository/ShopImageBulkRepository.java
+++ b/src/main/java/org/kwakmunsu/dingdongpang/domain/shopimage/repository/ShopImageBulkRepository.java
@@ -1,0 +1,28 @@
+package org.kwakmunsu.dingdongpang.domain.shopimage.repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class ShopImageBulkRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public void saveShopImagesBulk(List<String> uploadedImages, Long shopId) {
+        String sql = "INSERT INTO shop_image (shop_id, image, created_at, updated_at) VALUES (?, ?, ?, ?)";
+
+        LocalDateTime now = LocalDateTime.now();
+        jdbcTemplate.batchUpdate(sql, uploadedImages, uploadedImages.size(),
+                (ps, imageUrl) -> {
+                    ps.setLong(1, shopId);
+                    ps.setString(2, imageUrl);
+                    ps.setObject(3, now);
+                    ps.setObject(4, now);
+                });
+    }
+
+}

--- a/src/main/java/org/kwakmunsu/dingdongpang/domain/shopimage/repository/ShopImageRepository.java
+++ b/src/main/java/org/kwakmunsu/dingdongpang/domain/shopimage/repository/ShopImageRepository.java
@@ -2,6 +2,7 @@ package org.kwakmunsu.dingdongpang.domain.shopimage.repository;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.kwakmunsu.dingdongpang.domain.shop.entity.Shop;
 import org.kwakmunsu.dingdongpang.domain.shopimage.entity.ShopImage;
 import org.springframework.stereotype.Repository;
 
@@ -10,6 +11,7 @@ import org.springframework.stereotype.Repository;
 public class ShopImageRepository {
 
     private final ShopImageJpaRepository shopImageJpaRepository;
+    private final ShopImageBulkRepository shopImageBulkRepository;
 
     public void save(ShopImage shopImage) {
         shopImageJpaRepository.save(shopImage);
@@ -17,6 +19,9 @@ public class ShopImageRepository {
 
     public void saveAll(List<ShopImage> shopImages) {
         shopImageJpaRepository.saveAll(shopImages);
+    }
+    public void saveAll(List<String> shopImages, Shop shop) {
+        shopImageBulkRepository.saveShopImagesBulk(shopImages, shop.getId());
     }
 
     public List<String> findByShopId(Long shopId) {

--- a/src/main/java/org/kwakmunsu/dingdongpang/domain/subscribeshop/controller/SubscribeDocsController.java
+++ b/src/main/java/org/kwakmunsu/dingdongpang/domain/subscribeshop/controller/SubscribeDocsController.java
@@ -9,13 +9,11 @@ import static org.kwakmunsu.dingdongpang.global.exception.dto.ErrorStatus.UNAUTH
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.kwakmunsu.dingdongpang.domain.shop.repository.shop.dto.ShopListResponse;
 import org.kwakmunsu.dingdongpang.domain.subscribeshop.repository.dto.SubscribeShopListResponse;
 import org.kwakmunsu.dingdongpang.domain.subscribeshop.service.dto.DailySubscriptionListResponse;
 import org.kwakmunsu.dingdongpang.global.swagger.ApiExceptions;

--- a/src/test/java/org/kwakmunsu/dingdongpang/domain/inquiry/controller/InquiryControllerTest.java
+++ b/src/test/java/org/kwakmunsu/dingdongpang/domain/inquiry/controller/InquiryControllerTest.java
@@ -1,7 +1,6 @@
 package org.kwakmunsu.dingdongpang.domain.inquiry.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.kwakmunsu.dingdongpang.global.util.TimeConverter.dateTimeToString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;

--- a/src/test/java/org/kwakmunsu/dingdongpang/domain/notification/service/NotificationQueryServiceTest.java
+++ b/src/test/java/org/kwakmunsu/dingdongpang/domain/notification/service/NotificationQueryServiceTest.java
@@ -1,7 +1,6 @@
 package org.kwakmunsu.dingdongpang.domain.notification.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.kwakmunsu.dingdongpang.global.util.TimeConverter.dateTimeToString;
 
 import java.sql.Timestamp;
 import java.time.LocalDateTime;

--- a/src/test/java/org/kwakmunsu/dingdongpang/domain/shop/service/ShopCommandServiceTest.java
+++ b/src/test/java/org/kwakmunsu/dingdongpang/domain/shop/service/ShopCommandServiceTest.java
@@ -41,7 +41,8 @@ record ShopCommandServiceTest(
             Point point = GeoFixture.createPoint(1.2, 2.3);
 
             shopCommandService.register(shopRegisterServiceRequest, point, 1L);
-
+            entityManager.clear();
+            entityManager.flush();
             boolean exists = shopRepository.existsByBusinessNumber(shopRegisterServiceRequest.businessNumber());
 
             assertThat(exists).isTrue();


### PR DESCRIPTION
## #️⃣연관된 이슈
✅ `Issue`:  #86 

## 📝작업 내용
- Before
매장 등록 시 JPA 쿼리로 최대 이미지 저장 쿼리 5번, 운영시간 저장 쿼리 7번 , 매장 정보 저장 1번 총 13번의 쿼리가 날라감.
추후 이미지 저장 갯수는 늘어날수 있기에 매장 등록 시 많은 쿼리가 진행됨. 

- After
JDBC Template 배치 를 이용해 이미지 저장 쿼리 1번, 운영시간 저장쿼리 1번, 매장 정보 저장 쿼리 1번으로 축소.

## 네트워크 통신 감소
Before: 13번의 서버 ↔ DB 통신
After: 3번의 서버 ↔ DB 통신
통신 횟수: 77% 감소